### PR TITLE
Isolate FTP deploy state so dist uploads cannot delete /subdomains/*.

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Deploy dist/ to Hostinger via FTPS
         # Note: stale PHP files on the server root must be removed manually once after cutover.
-        # dangerous-clean-slate is intentionally off — it would also wipe /subdomains/* on Hostinger.
+        # Use a dist-specific state file so the legacy full-repo state does not delete /subdomains/*.
         uses: SamKirkland/FTP-Deploy-Action@v4.3.5
         with:
           server: ${{ secrets.HOSTINGER_FTPS_SERVER }}
@@ -49,9 +49,12 @@ jobs:
           password: ${{ secrets.HOSTINGER_FTPS_PASSWORD }}
           protocol: ftps
           local-dir: ./dist/
+          state-name: .ftp-deploy-sync-state-dist.json
+          dangerous-clean-slate: false
           exclude: |
             **/.git*
             **/.git*/**
+            **/subdomains/**
 
   deploy-subdomains:
     needs: build
@@ -69,3 +72,5 @@ jobs:
           protocol: ftps
           local-dir: ./subdomains/tourguide/
           server-dir: /subdomains/tourguide/
+          state-name: .ftp-deploy-sync-state-subdomains-tourguide.json
+          dangerous-clean-slate: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,7 +121,7 @@ npm run test:content && npm run build && npm run test:verify
 ## Deploy
 
 - `main` branch: CI runs `npm ci`, sync assets, `npm run check`, `npm run test:unit`, `npm run test:content`, `npm run build`, `npm run test:verify`, Playwright E2E
-- Deploy uploads `./dist/`; remove stale PHP files on the server root manually once after cutover (`dangerous-clean-slate` is off to protect `/subdomains/*`)
+- Deploy uploads `./dist/` with `state-name: .ftp-deploy-sync-state-dist.json` and `dangerous-clean-slate: false` so the legacy full-repo FTP state cannot delete `/subdomains/*`; remove stale PHP files on the server root manually once after cutover
 - `subdomains/tourguide/` has a separate FTPS step
 
 ## Never Edit or Commit

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -67,7 +67,7 @@ Markdown body = case study HTML sections (former `#projContent`).
 ## Deploy
 
 - CI: `npm ci` → sync assets → check → test → build → verify → Playwright E2E
-- Deploy: `dist/` via FTPS with `dangerous-clean-slate: true` (removes stale server files)
+- Deploy: `dist/` via FTPS with `dangerous-clean-slate: false` and a dist-specific state file (does not touch `/subdomains/*`)
 - `public/.htaccess` → copied to `dist/` for Apache directory index and trailing slashes
 
 ## Subdomains


### PR DESCRIPTION
The Astro cutover reused the legacy full-repo sync state, which caused FTP-Deploy-Action to remove subdomain paths no longer present in dist/.