### PR TITLE
Fix broken production images by pulling Git LFS in CI deploy.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -55,22 +57,3 @@ jobs:
             **/.git*
             **/.git*/**
             **/subdomains/**
-
-  deploy-subdomains:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Deploy tourguide subdomain
-        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
-        with:
-          server: ${{ secrets.HOSTINGER_FTPS_SERVER }}
-          username: ${{ secrets.HOSTINGER_FTPS_USERNAME }}
-          password: ${{ secrets.HOSTINGER_FTPS_PASSWORD }}
-          protocol: ftps
-          local-dir: ./subdomains/tourguide/
-          server-dir: /subdomains/tourguide/
-          state-name: .ftp-deploy-sync-state-subdomains-tourguide.json
-          dangerous-clean-slate: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ npm run test:e2e       # Playwright (after build)
 │   └── pages/de/            # DE routes
 ├── scripts/
 │   └── export-db-to-content.mjs
-├── subdomains/              # Separate deploy (tourguide, etc.)
+├── subdomains/              # Manual deploy only (tourguide, etc.)
 └── docs/
 ```
 
@@ -122,7 +122,7 @@ npm run test:content && npm run build && npm run test:verify
 
 - `main` branch: CI runs `npm ci`, sync assets, `npm run check`, `npm run test:unit`, `npm run test:content`, `npm run build`, `npm run test:verify`, Playwright E2E
 - Deploy uploads `./dist/` with `state-name: .ftp-deploy-sync-state-dist.json` and `dangerous-clean-slate: false` so the legacy full-repo FTP state cannot delete `/subdomains/*`; remove stale PHP files on the server root manually once after cutover
-- `subdomains/tourguide/` has a separate FTPS step
+- `subdomains/` are deployed manually via FTPS (not in CI)
 
 ## Never Edit or Commit
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -72,4 +72,4 @@ Markdown body = case study HTML sections (former `#projContent`).
 
 ## Subdomains
 
-`subdomains/tourguide/` and others deploy separately; not part of Astro `dist/`.
+`subdomains/tourguide/` and others are deployed manually via FTPS; not part of Astro `dist/` or CI.

--- a/scripts/verify-build.mjs
+++ b/scripts/verify-build.mjs
@@ -21,6 +21,18 @@ function requirePath(relPath) {
   }
 }
 
+function assertNotLfsPointer(relPath) {
+  const full = path.join(dist, ...relPath.split('/'));
+  if (!fs.existsSync(full)) {
+    errors.push(relPath);
+    return;
+  }
+  const head = fs.readFileSync(full, 'utf8').slice(0, 40);
+  if (head.startsWith('version https://git-lfs.github.com/spec/v1')) {
+    errors.push(`LFS pointer (run git lfs pull): ${relPath}`);
+  }
+}
+
 function forbidPath(relPath) {
   const full = path.join(dist, ...relPath.split('/'));
   if (fs.existsSync(full)) {
@@ -105,6 +117,15 @@ if (!hasSitemap) {
 }
 
 forbidPath('tourguide');
+
+const lfsCheckedAssets = [
+  'assets/img/portrait.jpg',
+  'assets/img/portfolio.jpg',
+  'assets/img/lqip/futureEarth.jpg',
+];
+for (const assetPath of lfsCheckedAssets) {
+  assertNotLfsPointer(assetPath);
+}
 
 const publishedSlugs = getPublishedProjectSlugs();
 for (const slug of publishedSlugs) {


### PR DESCRIPTION
Enable LFS checkout in CI and deploy workflows so assets copied into dist/ are real binaries, add a verify-build guard for LFS pointer files, and remove automated subdomain FTPS deploy.