### PR TITLE
Publish Tourguide as a full case study at /tourguide instead of in-de…

### DIFF
--- a/e2e/in-development.spec.ts
+++ b/e2e/in-development.spec.ts
@@ -1,15 +1,15 @@
 import { test, expect } from './fixtures';
 
-test.describe('in-development routing', () => {
-  test('tourguide tile links to /development/tourguide', async ({ page }) => {
+test.describe('published project routing', () => {
+  test('tourguide tile links to /tourguide', async ({ page }) => {
     await page.goto('/projects');
 
-    const tourguideLink = page.locator('.projRow a[href="/development/tourguide"]');
+    const tourguideLink = page.locator('.projRow a[href="/tourguide"]');
     await expect(tourguideLink).toBeVisible();
 
     await tourguideLink.click();
 
-    await expect(page).toHaveURL(/\/development\/tourguide$/);
+    await expect(page).toHaveURL(/\/tourguide$/);
     await expect(page.locator('#projLanding h1')).toHaveText('Tourguide');
   });
 });

--- a/scripts/export-db-to-content.mjs
+++ b/scripts/export-db-to-content.mjs
@@ -113,7 +113,7 @@ const PROJECTS = [
   {
     slug: 'tourguide',
     order: 3,
-    inDevelopment: true,
+    inDevelopment: false,
     name: { en: 'Tourguide', de: 'Tourguide' },
     type: { en: 'Flutter App', de: 'Flutter App' },
     year: '2024',

--- a/scripts/validate-content.mjs
+++ b/scripts/validate-content.mjs
@@ -240,23 +240,8 @@ function checkProjects() {
 /**
  * @param {Map<string, { slug: string, inDevelopment: boolean, draft: boolean }>} projectsBySlug
  */
-function checkInDevelopmentRouting(projectsBySlug) {
-  for (const [slug, project] of projectsBySlug) {
-    if (project.inDevelopment && slug !== 'tourguide') {
-      fail(slug, 'inDevelopment', 'only tourguide may have inDevelopment: true');
-    }
-    if (!project.inDevelopment && slug === 'tourguide') {
-      fail(slug, 'inDevelopment', 'tourguide must have inDevelopment: true');
-    }
-  }
-
-  const publishedSlugs = [...projectsBySlug.values()]
-    .filter((project) => !project.draft && !project.inDevelopment)
-    .map((project) => project.slug);
-
-  if (publishedSlugs.includes('tourguide')) {
-    fail('tourguide', 'inDevelopment', 'tourguide must not be in published [slug] route set');
-  }
+function checkInDevelopmentRouting(_projectsBySlug) {
+  // inDevelopment projects are excluded from [slug] via Astro getStaticPaths filters.
 }
 
 function checkUiKeyParity() {

--- a/scripts/verify-build.mjs
+++ b/scripts/verify-build.mjs
@@ -98,10 +98,8 @@ const requiredPaths = [
   'projects/index.html',
   'about/index.html',
   'futureEarth/index.html',
-  'development/tourguide/index.html',
   'de/index.html',
   'de/futureEarth/index.html',
-  'de/development/tourguide/index.html',
 ];
 
 for (const relPath of requiredPaths) {
@@ -115,8 +113,6 @@ const hasSitemap =
 if (!hasSitemap) {
   errors.push('sitemap-index.xml or sitemap-0.xml');
 }
-
-forbidPath('tourguide');
 
 const lfsCheckedAssets = [
   'assets/img/portrait.jpg',

--- a/src/content/projects-de/tourguide.md
+++ b/src/content/projects-de/tourguide.md
@@ -7,7 +7,7 @@ projectType:
   en: "Flutter App"
   de: "Flutter App"
 year: "2024"
-inDevelopment: true
+inDevelopment: false
 roles: ["android", "design"]
 description:
   en: "A crossplatform Flutter app that helps users explore tours with navigation, information on places, and chat with an AI tourguide. A personal project currently in development."

--- a/src/content/projects/tourguide.md
+++ b/src/content/projects/tourguide.md
@@ -7,7 +7,7 @@ projectType:
   en: "Flutter App"
   de: "Flutter App"
 year: "2024"
-inDevelopment: true
+inDevelopment: false
 roles: ["android", "design"]
 description:
   en: "A crossplatform Flutter app that helps users explore tours with navigation, information on places, and chat with an AI tourguide. A personal project currently in development."

--- a/src/lib/projects.test.ts
+++ b/src/lib/projects.test.ts
@@ -117,19 +117,19 @@ describe('projectToTileData', () => {
     expect(projectToTileData(project, 'de').href).toBe('/de/futureEarth');
   });
 
-  it('routes in-development tourguide to /development/tourguide', () => {
+  it('routes published tourguide to /tourguide', () => {
     const project = mockProject('tourguide.md', {
       name: { en: 'Tourguide', de: 'Tourguide' },
       projectType: { en: 'Flutter App', de: 'Flutter App' },
-      inDevelopment: true,
+      inDevelopment: false,
       roles: ['android', 'design'],
     });
 
     expect(projectToTileData(project, 'en')).toMatchObject({
       slug: 'tourguide',
-      inDevelopment: true,
-      href: '/development/tourguide',
+      inDevelopment: false,
+      href: '/tourguide',
     });
-    expect(projectToTileData(project, 'de').href).toBe('/de/development/tourguide');
+    expect(projectToTileData(project, 'de').href).toBe('/de/tourguide');
   });
 });


### PR DESCRIPTION
…velopment routing.

Remove the incorrect inDevelopment flag and update validation, build checks, and tests to match.